### PR TITLE
feat: add orientation option for default template selection

### DIFF
--- a/R/save_table.R
+++ b/R/save_table.R
@@ -8,20 +8,21 @@
 #' @param table_data A data frame containing the table data to be exported.
 #' @param path A string specifying the file path where the table should be saved. The file extension determines
 #'   the format (currently only .docx is supported).
-#' @param template A string specifying the path to a Word template (.docx) to be used. If NULL, a default
-#'   template provided by the package is used.
+#' @param orientation A character string indicating the table's orientation when using the default template.
+#'   Options are `"landscape"` (default) or `"portrait"`. Ignored if a custom template is provided.
+#' @param template A string specifying the path to a custom Word template (.docx). If NULL, a default
+#'   template provided by the package is used, with orientation set by the `orientation` argument.
 #' @param digits An integer indicating the number of decimal places to use when formatting numeric columns.
 #'   Defaults to 3.
-#' @param ... Additional arguments passed to `flextable::tt` when exporting to Word.
-#'
 #' @details
 #' This function checks the file extension to determine the export format. Currently, only Word documents
 #' (.docx) are supported. The function formats the table using the `flextable` package and exports it
 #' using the `officer` package. Users can provide a custom Word template or rely on the package's default
-#' template.
+#' template, in either "landscape" or "portrait" orientation as set by the `orientation` argument.
 #'
 #' If the `path` has a .docx extension, the table will be saved as a Word document. The default template
-#' aligns the table to APA style, and the font is set to Arial with a font size of 10.
+#' aligns the table to APA style, with Arial font at size 12. If a custom template is provided via the
+#' `template` argument, it takes precedence over the `orientation` setting.
 #'
 #' @examples
 #' library(lavaan)
@@ -31,10 +32,12 @@
 #' fit1 <- cfa(model1, data = HolzingerSwineford1939, estimator = "MLR")
 #' fit2 <- cfa(model2, data = HolzingerSwineford1939, estimator = "MLR")
 #' fit_compared <- compare_model_fit(fit1, fit2)
-#' save_table(fit_compared, path = "model_fit.docx")
+#' save_table(fit_compared, path = "model_fit.docx", orientation = "landscape")
 #'
 #' @export
-save_table <- function(table_data, path, template = NULL, digits = 3, ...) {
+
+save_table <- function(table_data, path, orientation = "landscape",
+                       template = NULL, digits = 3, ...) {
   # Check if required packages are installed
   rlang::check_installed("tools")
 
@@ -47,9 +50,17 @@ save_table <- function(table_data, path, template = NULL, digits = 3, ...) {
     cli::cli_abort("Unsupported file format: {.val {file_extension}}. Currently, only .docx is supported.")
   }
 
-  # Set the default template if none is provided
+  # Set the default template based on orientation if none is provided
   if (is.null(template)) {
-    template <- system.file("templates", "template_vertical.docx", package = "psymetrics")
+    orientation <- match.arg(orientation, choices = c("landscape", "vertical"))
+    template <- if (orientation == "landscape") {
+      system.file("templates", "template_landscape.docx", package = "psymetrics")
+    } else {
+      system.file("templates", "template_vertical.docx", package = "psymetrics")
+    }
+  } else {
+    # Use the provided template and inform the user
+    cli::cli_inform("Using the provided template: {.file {template}}. The table orientation will follow this template.")
   }
 
   table_data <- prepare_table(table_data, digits = digits)

--- a/man/save_table.Rd
+++ b/man/save_table.Rd
@@ -4,7 +4,14 @@
 \alias{save_table}
 \title{Save a Table to a Specified Format}
 \usage{
-save_table(table_data, path, template = NULL, digits = 3, ...)
+save_table(
+  table_data,
+  path,
+  orientation = "landscape",
+  template = NULL,
+  digits = 3,
+  ...
+)
 }
 \arguments{
 \item{table_data}{A data frame containing the table data to be exported.}
@@ -12,13 +19,14 @@ save_table(table_data, path, template = NULL, digits = 3, ...)
 \item{path}{A string specifying the file path where the table should be saved. The file extension determines
 the format (currently only .docx is supported).}
 
-\item{template}{A string specifying the path to a Word template (.docx) to be used. If NULL, a default
-template provided by the package is used.}
+\item{orientation}{A character string indicating the table's orientation when using the default template.
+Options are \code{"landscape"} (default) or \code{"portrait"}. Ignored if a custom template is provided.}
+
+\item{template}{A string specifying the path to a custom Word template (.docx). If NULL, a default
+template provided by the package is used, with orientation set by the \code{orientation} argument.}
 
 \item{digits}{An integer indicating the number of decimal places to use when formatting numeric columns.
 Defaults to 3.}
-
-\item{...}{Additional arguments passed to \code{flextable::tt} when exporting to Word.}
 }
 \description{
 \code{save_table()} exports a table to various formats, with current support for Word documents (.docx).
@@ -29,10 +37,11 @@ sizes, and alignment options.
 This function checks the file extension to determine the export format. Currently, only Word documents
 (.docx) are supported. The function formats the table using the \code{flextable} package and exports it
 using the \code{officer} package. Users can provide a custom Word template or rely on the package's default
-template.
+template, in either "landscape" or "portrait" orientation as set by the \code{orientation} argument.
 
 If the \code{path} has a .docx extension, the table will be saved as a Word document. The default template
-aligns the table to APA style, and the font is set to Arial with a font size of 10.
+aligns the table to APA style, with Arial font at size 12. If a custom template is provided via the
+\code{template} argument, it takes precedence over the \code{orientation} setting.
 }
 \examples{
 library(lavaan)
@@ -42,6 +51,6 @@ model2 <- 'visual  =~ x1 + x2 + x3 + x4 + x5'
 fit1 <- cfa(model1, data = HolzingerSwineford1939, estimator = "MLR")
 fit2 <- cfa(model2, data = HolzingerSwineford1939, estimator = "MLR")
 fit_compared <- compare_model_fit(fit1, fit2)
-save_table(fit_compared, path = "model_fit.docx")
+save_table(fit_compared, path = "model_fit.docx", orientation = "landscape")
 
 }


### PR DESCRIPTION
Adds an `orientation` parameter to the `save_table` function to  allow users to specify the table's orientation when using the  default template. The function now selects the appropriate  template based on the specified orientation, defaulting to  "landscape". Updates documentation to reflect these changes.