### PR TITLE
feat: increase logo size in README files

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 # psymetrics
 
 <!-- badges: start --> <!-- badges: end --> 
-<img src="man/figures/hexlogo.png" align="right" width="120" />
+<img src="man/figures/hexlogo.png" align="right" width="200" />
 
 The goal of psymetrics is to provide tools for extracting and visualizing psychometric model fit indices. It is compatible with models created using packages like lavaan, psych, and mirt.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <!-- badges: start -->
 <!-- badges: end -->
 
-<img src="man/figures/hexlogo.png" align="right" width="120" />
+<img src="man/figures/hexlogo.png" align="right" width="200" />
 
 The goal of psymetrics is to provide tools for extracting and
 visualizing psychometric model fit indices. It is compatible with models


### PR DESCRIPTION
Update the logo size in both README.md and README.Rmd 120px  to 200px for better visibility and improved aesthetics. This change  enhances the overall presentation of the project documentation.